### PR TITLE
Add new validator to ignore special characters

### DIFF
--- a/library/src/main/java/co/kyash/vtl/validators/NoSpecialCharacterValidator.kt
+++ b/library/src/main/java/co/kyash/vtl/validators/NoSpecialCharacterValidator.kt
@@ -1,0 +1,45 @@
+package co.kyash.vtl.validators
+
+import android.content.Context
+import co.kyash.vtl.VtlValidationFailureException
+import io.reactivex.Completable
+import io.reactivex.schedulers.Schedulers
+
+/**
+ * Validation error when the text contains special characters.
+ */
+class NoSpecialCharacterValidator(
+        private val errorMessage: String
+) : VtlValidator {
+    companion object {
+        private const val VS15 = '\uFE0E'
+        private const val VS16 = '\uFE0F'
+
+        private const val ZERO_WIDTH_JOINER = '\u200D'
+        private const val ENCLOSING_KEYCAP = '\u20E3'
+    }
+
+    override fun validateAsCompletable(context: Context, text: String?): Completable =
+            Completable.fromRunnable {
+                if (!validate(text)) {
+                    throw VtlValidationFailureException(errorMessage)
+                }
+            }.subscribeOn(Schedulers.computation())
+
+    override fun validate(text: String?): Boolean {
+        if (text.isNullOrBlank()) {
+            return true
+        }
+        return text.none {
+            val type = Character.getType(it).toByte()
+            it == VS15
+                    || it == VS16
+                    || it == ZERO_WIDTH_JOINER
+                    || it == ENCLOSING_KEYCAP
+                    || type == Character.SURROGATE
+                    || type == Character.OTHER_SYMBOL
+        }
+    }
+
+    override fun getErrorMessage(): String? = errorMessage
+}

--- a/library/src/test/java/co/kyash/vtl/validators/NoSpecialCharacterValidatorTest.kt
+++ b/library/src/test/java/co/kyash/vtl/validators/NoSpecialCharacterValidatorTest.kt
@@ -1,0 +1,77 @@
+package co.kyash.vtl.validators
+
+import android.content.Context
+import co.kyash.vtl.testing.RxImmediateSchedulerRule
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class NoSpecialCharacterValidatorTest(
+        private val text: String?,
+        private val result: Boolean,
+        private val errorMessage: String?
+) {
+    companion object {
+        private const val ERROR_MESSAGE = "This contains special characters"
+
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters
+        fun data(): List<Array<out Any?>> =
+                listOf(
+                        // CJK Unified Ideographs Extension B
+                        arrayOf("\uD844\uDE3D", false, ERROR_MESSAGE),
+                        // Folded Hands
+                        arrayOf("\uD83D\uDE4F", false, ERROR_MESSAGE),
+                        // Grinning Face
+                        arrayOf("\uD83D\uDE00", false, ERROR_MESSAGE),
+                        // Telephone
+                        arrayOf("\u260E\uFE0F", false, ERROR_MESSAGE),
+                        // Telephone
+                        arrayOf("\u260E\uFE0E", false, ERROR_MESSAGE),
+                        // Man Astronaut
+                        arrayOf("\uD83D\uDC68\u200D\uD83D\uDE80", false, ERROR_MESSAGE),
+                        // Skin Tone
+                        arrayOf("\uD83C\uDFFD", false, ERROR_MESSAGE),
+                        // Keycap Digit 1
+                        arrayOf("1\uFE0F\u20E3", false, ERROR_MESSAGE),
+                        arrayOf(null, true, null),
+                        arrayOf("   ", true, null),
+                        arrayOf("ABCD", true, null),
+                        arrayOf("あいうえお", true, null),
+                        arrayOf("Aaあ文1!@#$%^&*()_=-+\";:'{}|\\[]<>?,.", true, null),
+                        // CJK Unified Ideographs Extension A
+                        arrayOf("\u4DB5", true, null)
+                )
+    }
+
+    @get:Rule
+    val rxImmediateSchedulerRule = RxImmediateSchedulerRule()
+
+    private lateinit var validator: VtlValidator
+
+    private val context: Context = RuntimeEnvironment.application
+
+    @Before
+    fun setUp() {
+        validator = NoSpecialCharacterValidator(ERROR_MESSAGE)
+    }
+
+    @Test
+    fun validate() {
+        assertEquals(result, validator.validate(text))
+    }
+
+    @Test
+    fun validateAsCompletable() {
+        if (errorMessage == null) {
+            validator.validateAsCompletable(context, text).test().assertNoErrors().assertComplete()
+        } else {
+            validator.validateAsCompletable(context, text).test().assertErrorMessage(errorMessage)
+        }
+    }
+}


### PR DESCRIPTION
close #ISSUE_NUMBER

# Overview

- Add validator to ignore special characters.

## Special characters

- Emojis
- Surrogate pairs
  - ex. CJK Unified Ideographs Extension B-F

# Links
-

# Screenshots

Before | After
:--: | :--:
<img src="" width="300"> | <img src="" width="300">
